### PR TITLE
Fix React import in LoadingProvider

### DIFF
--- a/src/pages/Portfolio/Projects/Benefits/components/loading-provider/LoadingProvider.jsx
+++ b/src/pages/Portfolio/Projects/Benefits/components/loading-provider/LoadingProvider.jsx
@@ -1,5 +1,4 @@
-import {
-  React,
+import React, {
   createContext,
   useContext,
   useEffect,


### PR DESCRIPTION
## Summary
- correct React import in LoadingProvider provider to pull `createContext`, `useContext`, `useEffect`, `useState`, and `useReducer` from React

## Testing
- `npm test` *(fails: missing script)*
- `npx vitest run` *(fails: `document is not defined`)*
- `npx vitest run --environment jsdom` *(fails: cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68770067bed8832f81dca73e118cc3cb